### PR TITLE
Add command to take screenshots of Shifts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,16 @@
 # Shift Screenshots
 This project recreates the GitHub Pull Request screens to allow automating the process of taking screenshots for each of the individual Shifts.
 
+## System Requirements
+
+In addition to the standard Laravel requirements, this project has the following system requirements:
+
+* The PHP GD extension
+* Optipng
+* Pngquant 2
+
+See [spatie/image-optimizer](https://github.com/spatie/image-optimizer#optimization-tools) for installation instructions on various operating systems.
+
 ## Installation
 The following commands will install the project dependencies:
 

--- a/app/Console/Commands/TakeScreenshot.php
+++ b/app/Console/Commands/TakeScreenshot.php
@@ -15,7 +15,7 @@ class TakeScreenshot extends Command
     public function handle()
     {
         $shifts = is_null($this->argument('shift')) ? Shift::all()
-            : [Shift::findOrFail($this->argument('shift'))];
+            : [Shift::where('sku', $this->argument('shift'))->firstOrFail()];
 
         foreach ($shifts as $shift) {
             $html = view('shift.show', [

--- a/app/Console/Commands/TakeScreenshot.php
+++ b/app/Console/Commands/TakeScreenshot.php
@@ -5,6 +5,7 @@ namespace App\Console\Commands;
 use App\Models\Shift;
 use Illuminate\Console\Command;
 use Spatie\Browsershot\Browsershot;
+use Spatie\Image\Image;
 
 class TakeScreenshot extends Command
 {
@@ -23,10 +24,16 @@ class TakeScreenshot extends Command
                 'view' => 'commits',
             ])->render();
 
+            $path = public_path('images/screenshots/' . $shift->sku . '.png');
+
             Browsershot::html($html)
                 ->windowSize(1200, 628)
                 ->deviceScaleFactor(2)
-                ->save(public_path('images/screenshots/' . $shift->sku . '.png'));
+                ->save($path);
+
+            Image::load($path)
+                ->optimize()
+                ->save();
         }
 
         return 0;

--- a/app/Console/Commands/TakeScreenshot.php
+++ b/app/Console/Commands/TakeScreenshot.php
@@ -8,48 +8,26 @@ use Spatie\Browsershot\Browsershot;
 
 class TakeScreenshot extends Command
 {
-    /**
-     * The name and signature of the console command.
-     *
-     * @var string
-     */
-    protected $signature = 'screenshot:take {shift} {path}';
+    protected $signature = 'screenshot {shift?}';
 
-    /**
-     * The console command description.
-     *
-     * @var string
-     */
-    protected $description = 'Take a screenshot of the given Shift';
+    protected $description = 'Take screenshot of the given Shift or all Shifts';
 
-    /**
-     * Create a new command instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        parent::__construct();
-    }
-
-    /**
-     * Execute the console command.
-     *
-     * @return int
-     */
     public function handle()
     {
-        $shift = Shift::findOrFail($this->argument('shift'));
+        $shifts = is_null($this->argument('shift')) ? Shift::all()
+            : [Shift::findOrFail($this->argument('shift'))];
 
-        $html = view('shift.show', [
-            'shift' => $shift,
-            'view' => 'commits',
-        ])->render();
+        foreach ($shifts as $shift) {
+            $html = view('shift.show', [
+                'shift' => $shift,
+                'view' => 'commits',
+            ])->render();
 
-        Browsershot::html($html)
-            ->windowSize(1200, 628)
-            ->deviceScaleFactor(2)
-            ->save($this->argument('path'));
+            Browsershot::html($html)
+                ->windowSize(1200, 628)
+                ->deviceScaleFactor(2)
+                ->save(public_path('images/screenshots/' . $shift->sku . '.png'));
+        }
 
         return 0;
     }

--- a/app/Console/Commands/TakeScreenshot.php
+++ b/app/Console/Commands/TakeScreenshot.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Shift;
+use Illuminate\Console\Command;
+use Spatie\Browsershot\Browsershot;
+
+class TakeScreenshot extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'screenshot:take {shift} {path}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Take a screenshot of the given Shift';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $shift = Shift::findOrFail($this->argument('shift'));
+
+        $html = view('shift.show', [
+            'shift' => $shift,
+            'view' => 'commits',
+        ])->render();
+
+        Browsershot::html($html)
+            ->windowSize(1200, 628)
+            ->deviceScaleFactor(2)
+            ->save($this->argument('path'));
+
+        return 0;
+    }
+}

--- a/app/Models/Shift.php
+++ b/app/Models/Shift.php
@@ -11,6 +11,7 @@ class Shift extends Model
 
     protected $fillable = [
         'name',
+        'sku',
         'type',
         'published_at',
     ];

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
     "license": "MIT",
     "require": {
         "php": "^7.3|^8.0",
+        "ext-gd": "*",
         "fruitcake/laravel-cors": "^2.0",
         "guzzlehttp/guzzle": "^7.0.1",
         "laravel/framework": "^8.75",

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
         "guzzlehttp/guzzle": "^7.0.1",
         "laravel/framework": "^8.75",
         "laravel/sanctum": "^2.11",
-        "laravel/tinker": "^2.5"
+        "laravel/tinker": "^2.5",
+        "spatie/browsershot": "^3.52"
     },
     "require-dev": {
         "facade/ignition": "^2.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c61ff82cbf0142a401a48a8161e1595a",
+    "content-hash": "f17968e1665c237ec5788768e5b76b0f",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -885,6 +885,90 @@
             "time": "2021-10-06T17:43:30+00:00"
         },
         {
+            "name": "intervention/image",
+            "version": "2.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Intervention/image.git",
+                "reference": "744ebba495319501b873a4e48787759c72e3fb8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Intervention/image/zipball/744ebba495319501b873a4e48787759c72e3fb8c",
+                "reference": "744ebba495319501b873a4e48787759c72e3fb8c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-fileinfo": "*",
+                "guzzlehttp/psr7": "~1.1 || ^2.0",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "~0.9.2",
+                "phpunit/phpunit": "^4.8 || ^5.7 || ^7.5.15"
+            },
+            "suggest": {
+                "ext-gd": "to use GD library based image processing.",
+                "ext-imagick": "to use Imagick based image processing.",
+                "intervention/imagecache": "Caching extension for the Intervention Image library"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.4-dev"
+                },
+                "laravel": {
+                    "providers": [
+                        "Intervention\\Image\\ImageServiceProvider"
+                    ],
+                    "aliases": {
+                        "Image": "Intervention\\Image\\Facades\\Image"
+                    }
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Intervention\\Image\\": "src/Intervention/Image"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Oliver Vogel",
+                    "email": "oliver@olivervogel.com",
+                    "homepage": "http://olivervogel.com/"
+                }
+            ],
+            "description": "Image handling and manipulation library with support for Laravel integration",
+            "homepage": "http://image.intervention.io/",
+            "keywords": [
+                "gd",
+                "image",
+                "imagick",
+                "laravel",
+                "thumbnail",
+                "watermark"
+            ],
+            "support": {
+                "issues": "https://github.com/Intervention/image/issues",
+                "source": "https://github.com/Intervention/image/tree/2.7.1"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.me/interventionphp",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/Intervention",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-12-16T16:49:26+00:00"
+        },
+        {
             "name": "laravel/framework",
             "version": "v8.77.1",
             "source": {
@@ -1441,6 +1525,71 @@
                 }
             ],
             "time": "2021-12-09T09:40:50+00:00"
+        },
+        {
+            "name": "league/glide",
+            "version": "1.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/glide.git",
+                "reference": "ae5e26700573cb678919d28e425a8b87bc71c546"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/glide/zipball/ae5e26700573cb678919d28e425a8b87bc71c546",
+                "reference": "ae5e26700573cb678919d28e425a8b87bc71c546",
+                "shasum": ""
+            },
+            "require": {
+                "intervention/image": "^2.4",
+                "league/flysystem": "^1.0",
+                "php": "^7.2|^8.0",
+                "psr/http-message": "^1.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.3.3",
+                "phpunit/php-token-stream": "^3.1|^4.0",
+                "phpunit/phpunit": "^8.5|^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Glide\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jonathan Reinink",
+                    "email": "jonathan@reinink.ca",
+                    "homepage": "http://reinink.ca"
+                }
+            ],
+            "description": "Wonderfully easy on-demand image manipulation library with an HTTP based API.",
+            "homepage": "http://glide.thephpleague.com",
+            "keywords": [
+                "ImageMagick",
+                "editing",
+                "gd",
+                "image",
+                "imagick",
+                "league",
+                "manipulation",
+                "processing"
+            ],
+            "support": {
+                "issues": "https://github.com/thephpleague/glide/issues",
+                "source": "https://github.com/thephpleague/glide/tree/1.7.0"
+            },
+            "time": "2020-11-05T17:34:03+00:00"
         },
         {
             "name": "league/mime-type-detection",
@@ -2539,6 +2688,256 @@
                 }
             ],
             "time": "2021-09-25T23:10:38+00:00"
+        },
+        {
+            "name": "spatie/browsershot",
+            "version": "3.52.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/browsershot.git",
+                "reference": "4f8584e835035a4696a496c4508c3c35edaef28a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/browsershot/zipball/4f8584e835035a4696a496c4508c3c35edaef28a",
+                "reference": "4f8584e835035a4696a496c4508c3c35edaef28a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0",
+                "spatie/image": "^1.5.3|^2.0",
+                "spatie/temporary-directory": "^1.1|^2.0",
+                "symfony/process": "^4.2|^5.0|^6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0",
+                "spatie/phpunit-snapshot-assertions": "^4.2.3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\Browsershot\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "homepage": "https://github.com/freekmurze",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Convert a webpage to an image or pdf using headless Chrome",
+            "homepage": "https://github.com/spatie/browsershot",
+            "keywords": [
+                "chrome",
+                "convert",
+                "headless",
+                "image",
+                "pdf",
+                "puppeteer",
+                "screenshot",
+                "webpage"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/browsershot/issues",
+                "source": "https://github.com/spatie/browsershot/tree/3.52.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-12-17T23:11:39+00:00"
+        },
+        {
+            "name": "spatie/image",
+            "version": "1.10.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/image.git",
+                "reference": "897e819848096ea8eee8ed4a3531c6166f9a99e0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/image/zipball/897e819848096ea8eee8ed4a3531c6166f9a99e0",
+                "reference": "897e819848096ea8eee8ed4a3531c6166f9a99e0",
+                "shasum": ""
+            },
+            "require": {
+                "ext-exif": "*",
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "league/glide": "^1.6",
+                "php": "^7.2|^8.0",
+                "spatie/image-optimizer": "^1.1",
+                "spatie/temporary-directory": "^1.0|^2.0",
+                "symfony/process": "^3.0|^4.0|^5.0|^6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5.21|^9.5.4",
+                "symfony/var-dumper": "^4.0|^5.0|^6.0",
+                "vimeo/psalm": "^4.6"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\Image\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Manipulate images with an expressive API",
+            "homepage": "https://github.com/spatie/image",
+            "keywords": [
+                "image",
+                "spatie"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/image/issues",
+                "source": "https://github.com/spatie/image/tree/1.10.6"
+            },
+            "funding": [
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-12-21T10:01:09+00:00"
+        },
+        {
+            "name": "spatie/image-optimizer",
+            "version": "1.6.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/image-optimizer.git",
+                "reference": "6db75529cbf8fa84117046a9d513f277aead90a0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/image-optimizer/zipball/6db75529cbf8fa84117046a9d513f277aead90a0",
+                "reference": "6db75529cbf8fa84117046a9d513f277aead90a0",
+                "shasum": ""
+            },
+            "require": {
+                "ext-fileinfo": "*",
+                "php": "^7.3|^8.0",
+                "psr/log": "^1.0 | ^2.0 | ^3.0",
+                "symfony/process": "^4.2|^5.0|^6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5.21|^9.4.4",
+                "symfony/var-dumper": "^4.2|^5.0|^6.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\ImageOptimizer\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Easily optimize images using PHP",
+            "homepage": "https://github.com/spatie/image-optimizer",
+            "keywords": [
+                "image-optimizer",
+                "spatie"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/image-optimizer/issues",
+                "source": "https://github.com/spatie/image-optimizer/tree/1.6.2"
+            },
+            "time": "2021-12-21T10:08:05+00:00"
+        },
+        {
+            "name": "spatie/temporary-directory",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/temporary-directory.git",
+                "reference": "06fe0f10d068fdf145c9b2235030e568c913bb61"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/temporary-directory/zipball/06fe0f10d068fdf145c9b2235030e568c913bb61",
+                "reference": "06fe0f10d068fdf145c9b2235030e568c913bb61",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\TemporaryDirectory\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alex Vanderbist",
+                    "email": "alex@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Easily create, use and destroy temporary directories",
+            "homepage": "https://github.com/spatie/temporary-directory",
+            "keywords": [
+                "php",
+                "spatie",
+                "temporary-directory"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/temporary-directory/issues",
+                "source": "https://github.com/spatie/temporary-directory/tree/2.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-03-30T19:46:13+00:00"
         },
         {
             "name": "swiftmailer/swiftmailer",

--- a/database/migrations/2021_12_30_163259_create_shifts_table.php
+++ b/database/migrations/2021_12_30_163259_create_shifts_table.php
@@ -16,6 +16,7 @@ class CreateShiftsTable extends Migration
         Schema::create('shifts', function (Blueprint $table) {
             $table->id();
             $table->string('name');
+            $table->string('sku');
             $table->string('type');
             $table->dateTime('published_at')->nullable();
             $table->timestamps();

--- a/database/seeders/ShiftsSeeder.php
+++ b/database/seeders/ShiftsSeeder.php
@@ -12,6 +12,7 @@ class ShiftsSeeder extends Seeder
         // Laravel
         $shift = Shift::create([
             'name' => 'Laravel 5.0 Shift',
+            'sku' => '50',
             'type' => 'Laravel',
             'published_at' => '2015-02-04',
         ]);
@@ -28,6 +29,7 @@ class ShiftsSeeder extends Seeder
 
         $shift = Shift::create([
             'name' => 'Laravel 5.1 Shift',
+            'sku' => '51',
             'type' => 'Laravel',
             'published_at' => '2015-06-09',
         ]);
@@ -44,6 +46,7 @@ class ShiftsSeeder extends Seeder
 
         $shift = Shift::create([
             'name' => 'Laravel 5.2 Shift',
+            'sku' => '52',
             'type' => 'Laravel',
             'published_at' => '2015-12-21',
         ]);
@@ -60,6 +63,7 @@ class ShiftsSeeder extends Seeder
 
         $shift = Shift::create([
             'name' => 'Laravel 5.3 Shift',
+            'sku' => '53',
             'type' => 'Laravel',
             'published_at' => '2016-08-23',
         ]);
@@ -76,6 +80,7 @@ class ShiftsSeeder extends Seeder
 
         $shift = Shift::create([
             'name' => 'Laravel 5.4 Shift',
+            'sku' => '54',
             'type' => 'Laravel',
             'published_at' => '2017-01-24',
         ]);
@@ -92,6 +97,7 @@ class ShiftsSeeder extends Seeder
 
         $shift = Shift::create([
             'name' => 'Laravel 5.5 Shift',
+            'sku' => '55',
             'type' => 'Laravel',
             'published_at' => '2017-08-30',
         ]);
@@ -108,6 +114,7 @@ class ShiftsSeeder extends Seeder
 
         $shift = Shift::create([
             'name' => 'Laravel 5.6 Shift',
+            'sku' => '56',
             'type' => 'Laravel',
             'published_at' => '2018-02-07',
         ]);
@@ -124,6 +131,7 @@ class ShiftsSeeder extends Seeder
 
         $shift = Shift::create([
             'name' => 'Laravel 5.7 Shift',
+            'sku' => '57',
             'type' => 'Laravel',
             'published_at' => '2018-09-04',
         ]);
@@ -140,6 +148,7 @@ class ShiftsSeeder extends Seeder
 
         $shift = Shift::create([
             'name' => 'Laravel 5.8 Shift',
+            'sku' => '58',
             'type' => 'Laravel',
             'published_at' => '2019-02-26',
         ]);
@@ -157,6 +166,7 @@ class ShiftsSeeder extends Seeder
 
         $shift = Shift::create([
             'name' => 'Laravel 6.x Shift',
+            'sku' => '60',
             'type' => 'Laravel',
             'published_at' => '2019-09-03',
         ]);
@@ -173,6 +183,7 @@ class ShiftsSeeder extends Seeder
 
         $shift = Shift::create([
             'name' => 'Laravel 7.x Shift',
+            'sku' => '70',
             'type' => 'Laravel',
             'published_at' => '2020-03-03',
         ]);
@@ -189,6 +200,7 @@ class ShiftsSeeder extends Seeder
 
         $shift = Shift::create([
             'name' => 'Laravel 8.x Shift',
+            'sku' => '80',
             'type' => 'Laravel',
             'published_at' => '2020-09-08',
         ]);
@@ -205,8 +217,9 @@ class ShiftsSeeder extends Seeder
 
         $shift = Shift::create([
             'name' => 'Laravel 9.x Shift',
+            'sku' => '90',
             'type' => 'Laravel',
-            'published_at' => '2022-01-25',
+            'published_at' => '2022-02-08',
         ]);
         $shift->commits()->createMany([
             ['message' => 'Shift core files'],
@@ -222,6 +235,7 @@ class ShiftsSeeder extends Seeder
         // additional Shifts
         $shift = Shift::create([
             'name' => 'Upgrade Checker',
+            'sku' => 'UC',
             'type' => 'Laravel',
         ]);
         $shift->commits()->createMany([
@@ -233,11 +247,13 @@ class ShiftsSeeder extends Seeder
 
         $shift = Shift::create([
             'name' => 'Laravel Linter',
+            'sku' => 'LL',
             'type' => 'Laravel',
         ]);
 
         $shift = Shift::create([
             'name' => 'Laravel Fixer',
+            'sku' => 'LF',
             'type' => 'Laravel',
         ]);
         $shift->commits()->createMany([
@@ -253,6 +269,7 @@ class ShiftsSeeder extends Seeder
 
         $shift = Shift::create([
             'name' => 'Tests Generator',
+            'sku' => 'TG',
             'type' => 'Laravel',
         ]);
         $shift->commits()->createMany([
@@ -267,6 +284,7 @@ class ShiftsSeeder extends Seeder
 
         $shift = Shift::create([
             'name' => 'Namespace Models Shift',
+            'sku' => 'NM',
             'type' => 'Laravel',
         ]);
         $shift->commits()->createMany([
@@ -276,6 +294,7 @@ class ShiftsSeeder extends Seeder
 
         $shift = Shift::create([
             'name' => 'BrowserKit Tests Converter',
+            'sku' => 'T54',
             'type' => 'Laravel',
         ]);
         $shift->commits()->createMany([
@@ -287,11 +306,13 @@ class ShiftsSeeder extends Seeder
 
         $shift = Shift::create([
             'name' => 'Namespace Consolidator',
+            'sku' => 'CN',
             'type' => 'Laravel',
         ]);
 
         $shift = Shift::create([
             'name' => 'Dependency Upgrader',
+            'sku' => 'DU',
             'type' => 'Laravel',
         ]);
 
@@ -299,6 +320,7 @@ class ShiftsSeeder extends Seeder
         // Lumen
         $shift = Shift::create([
             'name' => 'Lumen to Laravel Shift',
+            'sku' => 'LTL',
             'type' => 'Lumen',
         ]);
         $shift->commits()->createMany([
@@ -315,6 +337,7 @@ class ShiftsSeeder extends Seeder
         // Tailwind
         $shift = Shift::create([
             'name' => 'Tailwind 1.x Shift',
+            'sku' => 'T1',
             'type' => 'Tailwind',
             'published_at' => '2019-05-13',
         ]);
@@ -331,6 +354,7 @@ class ShiftsSeeder extends Seeder
 
         $shift = Shift::create([
             'name' => 'Tailwind 2.x Shift',
+            'sku' => 'T2',
             'type' => 'Tailwind',
             'published_at' => '2020-11-18',
         ]);
@@ -347,6 +371,7 @@ class ShiftsSeeder extends Seeder
 
         $shift = Shift::create([
             'name' => 'Tailwind 3.x Shift',
+            'sku' => 'T3',
             'type' => 'Tailwind',
             'published_at' => '2021-12-09',
         ]);
@@ -362,6 +387,7 @@ class ShiftsSeeder extends Seeder
 
         $shift = Shift::create([
             'name' => 'Tailwind UI Shift',
+            'sku' => 'TU',
             'type' => 'Tailwind',
             'published_at' => '2020-11-18',
         ]);
@@ -378,6 +404,7 @@ class ShiftsSeeder extends Seeder
 
         $shift = Shift::create([
             'name' => 'Tailwind Converter',
+            'sku' => 'TC',
             'type' => 'Tailwind',
         ]);
         $shift->commits()->createMany([
@@ -392,6 +419,7 @@ class ShiftsSeeder extends Seeder
 
         $shift = Shift::create([
             'name' => 'Tailwind Linter',
+            'sku' => 'TL',
             'type' => 'Tailwind',
         ]);
         $shift->commits()->createMany([
@@ -403,39 +431,46 @@ class ShiftsSeeder extends Seeder
         // PHP
         $shift = Shift::create([
             'name' => 'PSR-2 Shift',
+            'sku' => 'P2',
             'type' => 'PHP',
         ]);
 
         $shift = Shift::create([
             'name' => 'PSR-4 Shift',
+            'sku' => 'P4',
             'type' => 'PHP',
         ]);
 
         $shift = Shift::create([
             'name' => 'MySQL to MySQLi Shift',
+            'sku' => 'MM',
             'type' => 'PHP',
         ]);
 
         $shift = Shift::create([
             'name' => 'PHPUnit 6 Shift',
+            'sku' => 'PU6',
             'type' => 'PHP',
             'published_at' => '2017-02-03',
         ]);
 
         $shift = Shift::create([
             'name' => 'PHPUnit 8 Shift',
+            'sku' => 'PU8',
             'type' => 'PHP',
             'published_at' => '2019-02-01',
         ]);
 
         $shift = Shift::create([
             'name' => 'PHPUnit 9 Shift',
+            'sku' => 'PU9',
             'type' => 'PHP',
             'published_at' => '2020-02-07',
         ]);
 
         $shift = Shift::create([
             'name' => 'Pest Converter',
+            'sku' => 'PP',
             'type' => 'PHP',
         ]);
         $shift->commits()->createMany([
@@ -451,6 +486,7 @@ class ShiftsSeeder extends Seeder
 
         $shift = Shift::create([
             'name' => 'CI Generator',
+            'sku' => 'CI',
             'type' => 'PHP',
         ]);
         $shift->commits()->createMany([

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,12 @@
 {
-    "name": "shift-screenshots",
+    "name": "screenshots",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
+            "dependencies": {
+                "puppeteer": "^13.2.0"
+            },
             "devDependencies": {
                 "@tailwindcss/typography": "^0.5.0",
                 "autoprefixer": "^10.4.1",
@@ -1931,7 +1934,7 @@
             "version": "17.0.5",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.5.tgz",
             "integrity": "sha512-w3mrvNXLeDYV1GKTZorGJQivK6XLCoGwpnyJFbJVK/aTBQUxOCaa/GlFAAN3OTDFcb7h5tiFG+YXCO2By+riZw==",
-            "dev": true
+            "devOptional": true
         },
         "node_modules/@types/parse-json": {
             "version": "4.0.0",
@@ -1950,6 +1953,15 @@
             "resolved": "https://registry.npmjs.org/@types/svgo/-/svgo-1.3.6.tgz",
             "integrity": "sha512-AZU7vQcy/4WFEuwnwsNsJnFwupIpbllH1++LXScN6uxT1Z4zPzdrWG97w4/I7eFKFTvfy/bHFStWjdBAg2Vjug==",
             "dev": true
+        },
+        "node_modules/@types/yauzl": {
+            "version": "2.9.2",
+            "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.2.tgz",
+            "integrity": "sha512-8uALY5LTvSuHgloDVUvWP3pIauILm+8/0pDMokuDYIoNsOkSwd5AiHBTSEJjKTDcZr5z8UpgOWZkxBF4iJftoA==",
+            "optional": true,
+            "dependencies": {
+                "@types/node": "*"
+            }
         },
         "node_modules/@webassemblyjs/ast": {
             "version": "1.11.1",
@@ -2209,6 +2221,17 @@
             "dev": true,
             "engines": {
                 "node": ">=0.4.0"
+            }
+        },
+        "node_modules/agent-base": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+            "dependencies": {
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6.0.0"
             }
         },
         "node_modules/aggregate-error": {
@@ -2531,14 +2554,12 @@
         "node_modules/balanced-match": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-            "dev": true
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
         },
         "node_modules/base64-js": {
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
             "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -2576,6 +2597,52 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/bl": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+            "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+            "dependencies": {
+                "buffer": "^5.5.0",
+                "inherits": "^2.0.4",
+                "readable-stream": "^3.4.0"
+            }
+        },
+        "node_modules/bl/node_modules/buffer": {
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+            "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "dependencies": {
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.1.13"
+            }
+        },
+        "node_modules/bl/node_modules/readable-stream": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+            "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+            "dependencies": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
             }
         },
         "node_modules/bn.js": {
@@ -2653,7 +2720,6 @@
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-            "dev": true,
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -2818,6 +2884,14 @@
                 "isarray": "^1.0.0"
             }
         },
+        "node_modules/buffer-crc32": {
+            "version": "0.2.13",
+            "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+            "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/buffer-from": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -2959,6 +3033,11 @@
             "optionalDependencies": {
                 "fsevents": "~2.3.2"
             }
+        },
+        "node_modules/chownr": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+            "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
         },
         "node_modules/chrome-trace-event": {
             "version": "1.0.3",
@@ -3174,8 +3253,7 @@
         "node_modules/concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-            "dev": true
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "node_modules/concat/node_modules/commander": {
             "version": "2.20.3",
@@ -3652,7 +3730,6 @@
             "version": "4.3.3",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
             "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-            "dev": true,
             "dependencies": {
                 "ms": "2.1.2"
             },
@@ -3810,6 +3887,11 @@
             "engines": {
                 "node": ">=0.8.0"
             }
+        },
+        "node_modules/devtools-protocol": {
+            "version": "0.0.960912",
+            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.960912.tgz",
+            "integrity": "sha512-I3hWmV9rWHbdnUdmMKHF2NuYutIM2kXz2mdXW8ha7TbRlGTVs+PF+PsB5QWvpCek4Fy9B+msiispCfwlhG5Sqg=="
         },
         "node_modules/didyoumean": {
             "version": "1.2.2",
@@ -4052,6 +4134,14 @@
             "dev": true,
             "engines": {
                 "node": ">= 0.8"
+            }
+        },
+        "node_modules/end-of-stream": {
+            "version": "1.4.4",
+            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+            "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+            "dependencies": {
+                "once": "^1.4.0"
             }
         },
         "node_modules/enhanced-resolve": {
@@ -4318,6 +4408,39 @@
                 }
             ]
         },
+        "node_modules/extract-zip": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+            "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+            "dependencies": {
+                "debug": "^4.1.1",
+                "get-stream": "^5.1.0",
+                "yauzl": "^2.10.0"
+            },
+            "bin": {
+                "extract-zip": "cli.js"
+            },
+            "engines": {
+                "node": ">= 10.17.0"
+            },
+            "optionalDependencies": {
+                "@types/yauzl": "^2.9.1"
+            }
+        },
+        "node_modules/extract-zip/node_modules/get-stream": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+            "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+            "dependencies": {
+                "pump": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -4371,6 +4494,14 @@
             },
             "engines": {
                 "node": ">=0.8.0"
+            }
+        },
+        "node_modules/fd-slicer": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+            "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
+            "dependencies": {
+                "pend": "~1.2.0"
             }
         },
         "node_modules/file-loader": {
@@ -4500,7 +4631,6 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
             "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-            "dev": true,
             "dependencies": {
                 "locate-path": "^5.0.0",
                 "path-exists": "^4.0.0"
@@ -4560,6 +4690,11 @@
                 "node": ">= 0.6"
             }
         },
+        "node_modules/fs-constants": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+            "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+        },
         "node_modules/fs-extra": {
             "version": "10.0.0",
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
@@ -4583,8 +4718,7 @@
         "node_modules/fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-            "dev": true
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
         },
         "node_modules/fsevents": {
             "version": "2.3.2",
@@ -4654,7 +4788,6 @@
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
             "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
-            "dev": true,
             "dependencies": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -5088,6 +5221,18 @@
             "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
             "dev": true
         },
+        "node_modules/https-proxy-agent": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+            "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+            "dependencies": {
+                "agent-base": "6",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
         "node_modules/human-signals": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
@@ -5125,7 +5270,6 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
             "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -5261,7 +5405,6 @@
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-            "dev": true,
             "dependencies": {
                 "once": "^1.3.0",
                 "wrappy": "1"
@@ -5270,8 +5413,7 @@
         "node_modules/inherits": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-            "dev": true
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         },
         "node_modules/internal-ip": {
             "version": "6.2.0",
@@ -5817,7 +5959,6 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
             "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-            "dev": true,
             "dependencies": {
                 "p-locate": "^4.1.0"
             },
@@ -6134,7 +6275,6 @@
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-            "dev": true,
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -6160,11 +6300,15 @@
                 "mkdirp": "bin/cmd.js"
             }
         },
+        "node_modules/mkdirp-classic": {
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+            "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
+        },
         "node_modules/ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-            "dev": true
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "node_modules/multicast-dns": {
             "version": "6.2.3",
@@ -6220,6 +6364,25 @@
             "dependencies": {
                 "lower-case": "^2.0.2",
                 "tslib": "^2.0.3"
+            }
+        },
+        "node_modules/node-fetch": {
+            "version": "2.6.7",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+            "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+            "dependencies": {
+                "whatwg-url": "^5.0.0"
+            },
+            "engines": {
+                "node": "4.x || >=6.0.0"
+            },
+            "peerDependencies": {
+                "encoding": "^0.1.0"
+            },
+            "peerDependenciesMeta": {
+                "encoding": {
+                    "optional": true
+                }
             }
         },
         "node_modules/node-forge": {
@@ -6428,7 +6591,6 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-            "dev": true,
             "dependencies": {
                 "wrappy": "1"
             }
@@ -6499,7 +6661,6 @@
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
             "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-            "dev": true,
             "dependencies": {
                 "p-try": "^2.0.0"
             },
@@ -6514,7 +6675,6 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
             "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-            "dev": true,
             "dependencies": {
                 "p-limit": "^2.2.0"
             },
@@ -6578,7 +6738,6 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
             "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-            "dev": true,
             "engines": {
                 "node": ">=6"
             }
@@ -6671,7 +6830,6 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
             "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -6680,7 +6838,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -6731,6 +6888,11 @@
                 "node": ">=0.12"
             }
         },
+        "node_modules/pend": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+            "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
+        },
         "node_modules/picocolors": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -6753,7 +6915,6 @@
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
             "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-            "dev": true,
             "dependencies": {
                 "find-up": "^4.0.0"
             },
@@ -7399,6 +7560,14 @@
             "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
             "dev": true
         },
+        "node_modules/progress": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+            "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
         "node_modules/proxy-addr": {
             "version": "2.0.7",
             "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -7421,6 +7590,11 @@
                 "node": ">= 0.10"
             }
         },
+        "node_modules/proxy-from-env": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+        },
         "node_modules/public-encrypt": {
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
@@ -7441,11 +7615,63 @@
             "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
             "dev": true
         },
+        "node_modules/pump": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+            "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+            "dependencies": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
+            }
+        },
         "node_modules/punycode": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
             "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
             "dev": true
+        },
+        "node_modules/puppeteer": {
+            "version": "13.2.0",
+            "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-13.2.0.tgz",
+            "integrity": "sha512-OSRcIgPq78Cjysm4AOvGgGN464qugfYZ1bJRpPZ7d6c2P/zVQmACblIiB56frVoSuHpvqo+ZphFJo7kF9V5iEg==",
+            "hasInstallScript": true,
+            "dependencies": {
+                "debug": "4.3.3",
+                "devtools-protocol": "0.0.960912",
+                "extract-zip": "2.0.1",
+                "https-proxy-agent": "5.0.0",
+                "node-fetch": "2.6.7",
+                "pkg-dir": "4.2.0",
+                "progress": "2.0.3",
+                "proxy-from-env": "1.1.0",
+                "rimraf": "3.0.2",
+                "tar-fs": "2.1.1",
+                "unbzip2-stream": "1.4.3",
+                "ws": "8.2.3"
+            },
+            "engines": {
+                "node": ">=10.18.1"
+            }
+        },
+        "node_modules/puppeteer/node_modules/ws": {
+            "version": "8.2.3",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
+            "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": "^5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
+            }
         },
         "node_modules/qs": {
             "version": "6.9.6",
@@ -7802,7 +8028,6 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
             "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-            "dev": true,
             "dependencies": {
                 "glob": "^7.1.3"
             },
@@ -8260,7 +8485,6 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
             "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-            "dev": true,
             "dependencies": {
                 "safe-buffer": "~5.2.0"
             }
@@ -8269,7 +8493,6 @@
             "version": "5.2.1",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
             "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -8482,6 +8705,45 @@
                 "node": ">=6"
             }
         },
+        "node_modules/tar-fs": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+            "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+            "dependencies": {
+                "chownr": "^1.1.1",
+                "mkdirp-classic": "^0.5.2",
+                "pump": "^3.0.0",
+                "tar-stream": "^2.1.4"
+            }
+        },
+        "node_modules/tar-stream": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+            "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+            "dependencies": {
+                "bl": "^4.0.3",
+                "end-of-stream": "^1.4.1",
+                "fs-constants": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^3.1.1"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/tar-stream/node_modules/readable-stream": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+            "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+            "dependencies": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
         "node_modules/terser": {
             "version": "5.10.0",
             "resolved": "https://registry.npmjs.org/terser/-/terser-5.10.0.tgz",
@@ -8583,6 +8845,11 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/through": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+        },
         "node_modules/thunky": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
@@ -8655,6 +8922,11 @@
                 "node": ">=0.6"
             }
         },
+        "node_modules/tr46": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+            "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+        },
         "node_modules/tslib": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
@@ -8678,6 +8950,38 @@
             },
             "engines": {
                 "node": ">= 0.6"
+            }
+        },
+        "node_modules/unbzip2-stream": {
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
+            "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
+            "dependencies": {
+                "buffer": "^5.2.1",
+                "through": "^2.3.8"
+            }
+        },
+        "node_modules/unbzip2-stream/node_modules/buffer": {
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+            "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "dependencies": {
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.1.13"
             }
         },
         "node_modules/unicode-canonical-property-names-ecmascript": {
@@ -8784,8 +9088,7 @@
         "node_modules/util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-            "dev": true
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
         },
         "node_modules/util/node_modules/inherits": {
             "version": "2.0.3",
@@ -8857,6 +9160,11 @@
             "dependencies": {
                 "minimalistic-assert": "^1.0.0"
             }
+        },
+        "node_modules/webidl-conversions": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+            "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
         },
         "node_modules/webpack": {
             "version": "5.65.0",
@@ -9234,6 +9542,15 @@
                 "node": ">=0.8.0"
             }
         },
+        "node_modules/whatwg-url": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+            "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+            "dependencies": {
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
+            }
+        },
         "node_modules/which": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -9275,8 +9592,7 @@
         "node_modules/wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-            "dev": true
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "node_modules/ws": {
             "version": "8.4.0",
@@ -9357,6 +9673,15 @@
             "dev": true,
             "engines": {
                 "node": ">=12"
+            }
+        },
+        "node_modules/yauzl": {
+            "version": "2.10.0",
+            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+            "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
+            "dependencies": {
+                "buffer-crc32": "~0.2.3",
+                "fd-slicer": "~1.1.0"
             }
         }
     },
@@ -10763,7 +11088,7 @@
             "version": "17.0.5",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.5.tgz",
             "integrity": "sha512-w3mrvNXLeDYV1GKTZorGJQivK6XLCoGwpnyJFbJVK/aTBQUxOCaa/GlFAAN3OTDFcb7h5tiFG+YXCO2By+riZw==",
-            "dev": true
+            "devOptional": true
         },
         "@types/parse-json": {
             "version": "4.0.0",
@@ -10782,6 +11107,15 @@
             "resolved": "https://registry.npmjs.org/@types/svgo/-/svgo-1.3.6.tgz",
             "integrity": "sha512-AZU7vQcy/4WFEuwnwsNsJnFwupIpbllH1++LXScN6uxT1Z4zPzdrWG97w4/I7eFKFTvfy/bHFStWjdBAg2Vjug==",
             "dev": true
+        },
+        "@types/yauzl": {
+            "version": "2.9.2",
+            "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.2.tgz",
+            "integrity": "sha512-8uALY5LTvSuHgloDVUvWP3pIauILm+8/0pDMokuDYIoNsOkSwd5AiHBTSEJjKTDcZr5z8UpgOWZkxBF4iJftoA==",
+            "optional": true,
+            "requires": {
+                "@types/node": "*"
+            }
         },
         "@webassemblyjs/ast": {
             "version": "1.11.1",
@@ -11011,6 +11345,14 @@
             "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
             "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
             "dev": true
+        },
+        "agent-base": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+            "requires": {
+                "debug": "4"
+            }
         },
         "aggregate-error": {
             "version": "3.1.0",
@@ -11266,14 +11608,12 @@
         "balanced-match": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-            "dev": true
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
         },
         "base64-js": {
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-            "dev": true
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
         },
         "batch": {
             "version": "0.6.1",
@@ -11292,6 +11632,37 @@
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
             "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
             "dev": true
+        },
+        "bl": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+            "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+            "requires": {
+                "buffer": "^5.5.0",
+                "inherits": "^2.0.4",
+                "readable-stream": "^3.4.0"
+            },
+            "dependencies": {
+                "buffer": {
+                    "version": "5.7.1",
+                    "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+                    "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+                    "requires": {
+                        "base64-js": "^1.3.1",
+                        "ieee754": "^1.1.13"
+                    }
+                },
+                "readable-stream": {
+                    "version": "3.6.0",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+                    "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                }
+            }
         },
         "bn.js": {
             "version": "5.2.0",
@@ -11364,7 +11735,6 @@
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-            "dev": true,
             "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -11501,6 +11871,11 @@
                 "isarray": "^1.0.0"
             }
         },
+        "buffer-crc32": {
+            "version": "0.2.13",
+            "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+            "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
+        },
         "buffer-from": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -11612,6 +11987,11 @@
                 "normalize-path": "~3.0.0",
                 "readdirp": "~3.6.0"
             }
+        },
+        "chownr": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+            "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
         },
         "chrome-trace-event": {
             "version": "1.0.3",
@@ -11798,8 +12178,7 @@
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-            "dev": true
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "connect-history-api-fallback": {
             "version": "1.6.0",
@@ -12160,7 +12539,6 @@
             "version": "4.3.3",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
             "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-            "dev": true,
             "requires": {
                 "ms": "2.1.2"
             }
@@ -12279,6 +12657,11 @@
                 "defined": "^1.0.0",
                 "minimist": "^1.1.1"
             }
+        },
+        "devtools-protocol": {
+            "version": "0.0.960912",
+            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.960912.tgz",
+            "integrity": "sha512-I3hWmV9rWHbdnUdmMKHF2NuYutIM2kXz2mdXW8ha7TbRlGTVs+PF+PsB5QWvpCek4Fy9B+msiispCfwlhG5Sqg=="
         },
         "didyoumean": {
             "version": "1.2.2",
@@ -12484,6 +12867,14 @@
             "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
             "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
             "dev": true
+        },
+        "end-of-stream": {
+            "version": "1.4.4",
+            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+            "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+            "requires": {
+                "once": "^1.4.0"
+            }
         },
         "enhanced-resolve": {
             "version": "5.8.3",
@@ -12691,6 +13082,27 @@
                 }
             }
         },
+        "extract-zip": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+            "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+            "requires": {
+                "@types/yauzl": "^2.9.1",
+                "debug": "^4.1.1",
+                "get-stream": "^5.1.0",
+                "yauzl": "^2.10.0"
+            },
+            "dependencies": {
+                "get-stream": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+                    "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+                    "requires": {
+                        "pump": "^3.0.0"
+                    }
+                }
+            }
+        },
         "fast-deep-equal": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -12738,6 +13150,14 @@
             "dev": true,
             "requires": {
                 "websocket-driver": ">=0.5.1"
+            }
+        },
+        "fd-slicer": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+            "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
+            "requires": {
+                "pend": "~1.2.0"
             }
         },
         "file-loader": {
@@ -12836,7 +13256,6 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
             "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-            "dev": true,
             "requires": {
                 "locate-path": "^5.0.0",
                 "path-exists": "^4.0.0"
@@ -12866,6 +13285,11 @@
             "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
             "dev": true
         },
+        "fs-constants": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+            "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+        },
         "fs-extra": {
             "version": "10.0.0",
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
@@ -12886,8 +13310,7 @@
         "fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-            "dev": true
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
         },
         "fsevents": {
             "version": "2.3.2",
@@ -12935,7 +13358,6 @@
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
             "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
-            "dev": true,
             "requires": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -13271,6 +13693,15 @@
             "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
             "dev": true
         },
+        "https-proxy-agent": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+            "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+            "requires": {
+                "agent-base": "6",
+                "debug": "4"
+            }
+        },
         "human-signals": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
@@ -13296,8 +13727,7 @@
         "ieee754": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-            "dev": true
+            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
         },
         "ignore": {
             "version": "5.2.0",
@@ -13385,7 +13815,6 @@
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-            "dev": true,
             "requires": {
                 "once": "^1.3.0",
                 "wrappy": "1"
@@ -13394,8 +13823,7 @@
         "inherits": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-            "dev": true
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         },
         "internal-ip": {
             "version": "6.2.0",
@@ -13793,7 +14221,6 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
             "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-            "dev": true,
             "requires": {
                 "p-locate": "^4.1.0"
             }
@@ -14048,7 +14475,6 @@
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-            "dev": true,
             "requires": {
                 "brace-expansion": "^1.1.7"
             }
@@ -14068,11 +14494,15 @@
                 "minimist": "^1.2.5"
             }
         },
+        "mkdirp-classic": {
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+            "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
+        },
         "ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-            "dev": true
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "multicast-dns": {
             "version": "6.2.3",
@@ -14116,6 +14546,14 @@
             "requires": {
                 "lower-case": "^2.0.2",
                 "tslib": "^2.0.3"
+            }
+        },
+        "node-fetch": {
+            "version": "2.6.7",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+            "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+            "requires": {
+                "whatwg-url": "^5.0.0"
             }
         },
         "node-forge": {
@@ -14276,7 +14714,6 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-            "dev": true,
             "requires": {
                 "wrappy": "1"
             }
@@ -14326,7 +14763,6 @@
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
             "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-            "dev": true,
             "requires": {
                 "p-try": "^2.0.0"
             }
@@ -14335,7 +14771,6 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
             "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-            "dev": true,
             "requires": {
                 "p-limit": "^2.2.0"
             }
@@ -14377,8 +14812,7 @@
         "p-try": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-            "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-            "dev": true
+            "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
         },
         "pako": {
             "version": "1.0.11",
@@ -14455,14 +14889,12 @@
         "path-exists": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-            "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-            "dev": true
+            "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
         },
         "path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-            "dev": true
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
         },
         "path-key": {
             "version": "3.1.1",
@@ -14501,6 +14933,11 @@
                 "sha.js": "^2.4.8"
             }
         },
+        "pend": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+            "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
+        },
         "picocolors": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -14517,7 +14954,6 @@
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
             "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-            "dev": true,
             "requires": {
                 "find-up": "^4.0.0"
             }
@@ -14923,6 +15359,11 @@
             "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
             "dev": true
         },
+        "progress": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+            "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
+        },
         "proxy-addr": {
             "version": "2.0.7",
             "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -14940,6 +15381,11 @@
                     "dev": true
                 }
             }
+        },
+        "proxy-from-env": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
         },
         "public-encrypt": {
             "version": "4.0.3",
@@ -14963,11 +15409,47 @@
                 }
             }
         },
+        "pump": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+            "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+            "requires": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
+            }
+        },
         "punycode": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
             "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
             "dev": true
+        },
+        "puppeteer": {
+            "version": "13.2.0",
+            "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-13.2.0.tgz",
+            "integrity": "sha512-OSRcIgPq78Cjysm4AOvGgGN464qugfYZ1bJRpPZ7d6c2P/zVQmACblIiB56frVoSuHpvqo+ZphFJo7kF9V5iEg==",
+            "requires": {
+                "debug": "4.3.3",
+                "devtools-protocol": "0.0.960912",
+                "extract-zip": "2.0.1",
+                "https-proxy-agent": "5.0.0",
+                "node-fetch": "2.6.7",
+                "pkg-dir": "4.2.0",
+                "progress": "2.0.3",
+                "proxy-from-env": "1.1.0",
+                "rimraf": "3.0.2",
+                "tar-fs": "2.1.1",
+                "unbzip2-stream": "1.4.3",
+                "ws": "8.2.3"
+            },
+            "dependencies": {
+                "ws": {
+                    "version": "8.2.3",
+                    "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
+                    "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
+                    "requires": {}
+                }
+            }
         },
         "qs": {
             "version": "6.9.6",
@@ -15236,7 +15718,6 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
             "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-            "dev": true,
             "requires": {
                 "glob": "^7.1.3"
             }
@@ -15626,7 +16107,6 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
             "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-            "dev": true,
             "requires": {
                 "safe-buffer": "~5.2.0"
             },
@@ -15634,8 +16114,7 @@
                 "safe-buffer": {
                     "version": "5.2.1",
                     "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-                    "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-                    "dev": true
+                    "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
                 }
             }
         },
@@ -15779,6 +16258,41 @@
             "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
             "dev": true
         },
+        "tar-fs": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+            "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+            "requires": {
+                "chownr": "^1.1.1",
+                "mkdirp-classic": "^0.5.2",
+                "pump": "^3.0.0",
+                "tar-stream": "^2.1.4"
+            }
+        },
+        "tar-stream": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+            "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+            "requires": {
+                "bl": "^4.0.3",
+                "end-of-stream": "^1.4.1",
+                "fs-constants": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^3.1.1"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "3.6.0",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+                    "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                }
+            }
+        },
         "terser": {
             "version": "5.10.0",
             "resolved": "https://registry.npmjs.org/terser/-/terser-5.10.0.tgz",
@@ -15835,6 +16349,11 @@
                     "dev": true
                 }
             }
+        },
+        "through": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
         },
         "thunky": {
             "version": "1.1.0",
@@ -15893,6 +16412,11 @@
             "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
             "dev": true
         },
+        "tr46": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+            "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+        },
         "tslib": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
@@ -15913,6 +16437,26 @@
             "requires": {
                 "media-typer": "0.3.0",
                 "mime-types": "~2.1.24"
+            }
+        },
+        "unbzip2-stream": {
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
+            "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
+            "requires": {
+                "buffer": "^5.2.1",
+                "through": "^2.3.8"
+            },
+            "dependencies": {
+                "buffer": {
+                    "version": "5.7.1",
+                    "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+                    "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+                    "requires": {
+                        "base64-js": "^1.3.1",
+                        "ieee754": "^1.1.13"
+                    }
+                }
             }
         },
         "unicode-canonical-property-names-ecmascript": {
@@ -16010,8 +16554,7 @@
         "util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-            "dev": true
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
         },
         "utils-merge": {
             "version": "1.0.1",
@@ -16065,6 +16608,11 @@
             "requires": {
                 "minimalistic-assert": "^1.0.0"
             }
+        },
+        "webidl-conversions": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+            "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
         },
         "webpack": {
             "version": "5.65.0",
@@ -16319,6 +16867,15 @@
             "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
             "dev": true
         },
+        "whatwg-url": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+            "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+            "requires": {
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
+            }
+        },
         "which": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -16348,8 +16905,7 @@
         "wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-            "dev": true
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "ws": {
             "version": "8.4.0",
@@ -16402,6 +16958,15 @@
             "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.0.tgz",
             "integrity": "sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA==",
             "dev": true
+        },
+        "yauzl": {
+            "version": "2.10.0",
+            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+            "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
+            "requires": {
+                "buffer-crc32": "~0.2.3",
+                "fd-slicer": "~1.1.0"
+            }
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -17,5 +17,8 @@
         "lodash": "^4.17.19",
         "postcss": "^8.4.5",
         "tailwindcss": "^3.0.8"
+    },
+    "dependencies": {
+        "puppeteer": "^13.2.0"
     }
 }

--- a/public/images/screenshots/.gitignore
+++ b/public/images/screenshots/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -4,7 +4,9 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Shift Screenshots</title>
-  <link href="{{ asset('css/app.css') }}" rel="stylesheet">
+  <style>
+    @php include(public_path('css/app.css')) @endphp
+  </style>
 </head>
 <body>
     @yield('content')

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Shift Screenshots</title>
   <style>
-    @php include(public_path('css/app.css')) @endphp
+    @php include public_path('css/app.css') @endphp
   </style>
 </head>
 <body>

--- a/resources/views/partials/commits.blade.php
+++ b/resources/views/partials/commits.blade.php
@@ -17,7 +17,10 @@
                         <h3 class="font-semibold text-gray-800">{{ $commit->message }}</h3>
                         <p class="mt-1 flex items-center gap-1 text-gray-600 text-xs">
                             <span class="inline-flex items-center gap-1">
-                                <img src="/images/shift-avatar.png" class="inline-block h-5 w-5 rounded-full" />
+                                <img
+                                    src="data:image/png;base64,{{ base64_encode(file_get_contents(public_path('images/shift-avatar.png'))) }}"
+                                    class="inline-block h-5 w-5 rounded-full"
+                                />
                                 <strong class="text-gray-800">laravel-shift</strong>
                             </span>
                             <span>committed {{ $minutes }} minutes ago</span>


### PR DESCRIPTION
This PR adds a `screenshot:take` command that accepts a Shift ID and a path to save the image to.

Screenshots are currently taken at a fixed resolution of 1200x628 at 2x DPI, but a command-line option could be added for this.

In order for the command to be able to run without starting the dev server, I needed to inline the CSS and avatar image.